### PR TITLE
Adding click event to toggle soft-wrap.

### DIFF
--- a/lib/soft-wrap-indicator-view.coffee
+++ b/lib/soft-wrap-indicator-view.coffee
@@ -16,6 +16,8 @@ class SoftWrapIndicatorView extends View
     atom.workspace.eachEditor (editor) =>
       @subscribe editor.displayBuffer, 'soft-wrap-changed', @update
 
+    @subscribe this, 'click', => @getActiveEditor()?.toggleSoftWrap()
+
   # Gets the currently active `Editor`.
   #
   # Returns the {Editor} that is currently active or `null` if there is not one active.


### PR DESCRIPTION
Hi. Thanks for sharing your soft-wrap-indicator package. 

I've added a one-liner that  adds a listener for click events on the indicator-view. The listener simply toggles the soft wrap status of the current editor. Hope you may find it as useful as I do.
