### PR TITLE
Use priority insertion into statusBar.

### DIFF
--- a/lib/soft-wrap-indicator-view.coffee
+++ b/lib/soft-wrap-indicator-view.coffee
@@ -10,7 +10,7 @@ class SoftWrapIndicatorView extends HTMLElement
 
   # Public: Attaches the indicator to the {StatusBarView}.
   attach: ->
-    @statusBar?.appendLeft(this)
+    @statusBar?.addLeftTile(item: this, priority: 150)
 
   # Public: Destroys and removes the indicator.
   destroy: ->

--- a/lib/soft-wrap-indicator.coffee
+++ b/lib/soft-wrap-indicator.coffee
@@ -5,7 +5,7 @@ class SoftWrapIndicator
   # Activates the package.
   activate: ->
     atom.packages.once 'activated', =>
-      {statusBar} = atom.workspaceView
+      statusBar = document.querySelector('status-bar')
       if statusBar?
         SoftWrapIndicatorView = require './soft-wrap-indicator-view'
         @view = new SoftWrapIndicatorView


### PR DESCRIPTION
As indicated in the status-bar documentation here
https://github.com/atom/status-bar#api

Rather than using appendLeft(), addLeftTile() is used and a priority for
the wrap indicator is given. The example code for status-bar uses a
priority of 100 and many Atom packages dealing with the status bar have
simply used that priority in their code. As such, I have picked a
priority of 150 so that the wrap indicator will hopefully appear to the
farthest right side of the elements on the left hand side of the side bar.

![screenshot](https://cloud.githubusercontent.com/assets/1903876/5667688/47cc5eae-972f-11e4-8632-d39b5edfc94e.png)
